### PR TITLE
Remove isolate scope as it's not actually dependant on the scope

### DIFF
--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -8,9 +8,6 @@
     .directive('fixedHeader', ['$timeout', function ($timeout) {
         return {
             restrict: 'A',
-            scope: {
-                tableHeight: '@'
-            },
             link: function ($scope, $elem, $attrs, $ctrl) {
                 function isVisible(el) {
                     var style = window.getComputedStyle(el);
@@ -55,7 +52,7 @@
 
                                 angular.element(elem.querySelectorAll('tbody')).css({
                                     'display': 'block',
-                                    'height': $scope.tableHeight || 'inherit',
+                                    'height': $attrs.tableHeight || 'inherit',
                                     'overflow': 'auto'
                                 });
 


### PR DESCRIPTION
I noticed that nothing is really being used on the isolated scope and I have another directive doing the sorting, filtering etc on the table element that already has the isolated scope.

Removing it shouldn't impact anything.