### PR TITLE
Support for max-height (via css & maxTableHeight) & fixes/improvements

### DIFF
--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -56,7 +56,7 @@
                     wrapper.style.visibility = 'invisible';
                     wrapper.appendChild(clone);
                     angular.element(clone.querySelectorAll('thead, tbody, tfoot')).css('display', '');
-                    $elem.parent()[0].appendChild(wrapper);
+                    $elem.after(wrapper);
 
                     // set widths of columns
                     var tableSections = ['tbody', 'thead', 'tfoot'];

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -59,32 +59,21 @@
                     $elem.parent()[0].appendChild(wrapper);
 
                     // set widths of columns
-                    var clonedTheadRow = clone.querySelector('table[fixed-header] > thead > tr:first-child');
-                    var clonedTrElems = clone.querySelectorAll('table[fixed-header] > tbody > tr');
-                    var clonedTrElem;
-                    var firstTrIdx = 0;
-                    for (; firstTrIdx < clonedTrElems.length; firstTrIdx++) { // Find the first tbody row that has the same number of columns as the header (no colspan'd cells)
-                        if (clonedTrElems[firstTrIdx].childElementCount === clonedTheadRow.childElementCount) {
-                            clonedTrElem = clonedTrElems[firstTrIdx];
-                            break;
+                    var tableSections = ['tbody', 'thead', 'tfoot'];
+                    for (var i = 0; i < tableSections.length; i++) {
+                        var lastRowLength = 0;
+                        var rows = elem.querySelectorAll('table[fixed-header] > ' + tableSections[i] +' > tr');
+                        var cloneRows = clone.querySelectorAll('table[fixed-header] > ' + tableSections[i] +' > tr');
+                        for (var j = 0; j < rows.length; j++) {
+                            var cells = rows[j].children;
+                            if (cells.length === lastRowLength) continue; // Don't bother applying width to rows that have the same number of columns as the prev. row
+                            lastRowLength = cells.length;
+                            for (var k = 0; k < cells.length; k++) {
+                                cells[k].style.width = cloneRows[j].children[k].offsetWidth + 'px';
+                            }
                         }
-                    }
-                    angular.forEach(clonedTheadRow.querySelectorAll('tr:first-child > th'), function (clonedThElem, i) {
-                        var clonedTdElems = clonedTrElem ? clonedTrElem.querySelector('th:nth-child(' + (i + 1) + '):not([colspan]), td:nth-child(' + (i + 1) + '):not([colspan])') : null;
-                        var columnWidth = clonedTdElems ? clonedTdElems.offsetWidth : clonedThElem.offsetWidth;
-                        var tdElems = elem.querySelector('table[fixed-header] > tbody > tr:nth-child(' + (firstTrIdx + 1) + ') > th:nth-child(' + (i + 1) + '), table[fixed-header] > tbody > tr:nth-child(' + (firstTrIdx + 1) + ') > td:nth-child(' + (i + 1) + ')');
-                        var thElems = elem.querySelector('table[fixed-header] > thead > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > thead > tr:first-child > td:nth-child(' + (i + 1) + ')');
-                        var tfElems = elem.querySelector('table[fixed-header] > tfoot > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tfoot > tr:first-child > td:nth-child(' + (i + 1) + ')');
-                        if (tdElems)  {
-                            tdElems.style.width = columnWidth + 'px';
-                        }
-                        if (thElems) {
-                            thElems.style.width = columnWidth + 'px';
-                        }
-                        if (tfElems)  {
-                            tfElems.style.width = columnWidth + 'px';
-                        }
-                    });
+                    };
+
                     
                     //Done with the math. We can get rid of the clone.
                     angular.element(wrapper).remove();
@@ -110,8 +99,10 @@
                     if (scrollBarWidth > 0) {
                         // for some reason trimming the width by 4px lines everything up better
                         scrollBarWidth -= 4;
-                        var lastColumn = elem.querySelector('table[fixed-header] > tbody > tr:first-child > td:last-child');
-                        lastColumn.style.width = (lastColumn.offsetWidth - scrollBarWidth) + 'px';
+                        var lastColumns = elem.querySelectorAll('table[fixed-header] > tbody > tr > td:last-child');
+                        for (i = 0; i < lastColumns.length; i++) {
+                            lastColumns[i].style.width = (lastColumns[i].offsetWidth - scrollBarWidth) + 'px';
+                        }
                     }
                 });
             }

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -57,11 +57,22 @@
                     wrapper.appendChild(clone);
                     angular.element(clone.querySelectorAll('thead, tbody, tfoot')).css('display', '');
                     $elem.parent()[0].appendChild(wrapper);
+
                     // set widths of columns
-                    angular.forEach(clone.querySelectorAll('table[fixed-header] > thead > tr:first-child > th'), function (clonedThElem, i) {
-                        var clonedTdElems = clone.querySelector('table[fixed-header] > tbody > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tbody > tr:first-child > td:nth-child(' + (i + 1) + ')');
+                    var clonedTheadRow = clone.querySelector('table[fixed-header] > thead > tr:first-child');
+                    var clonedTrElems = clone.querySelectorAll('table[fixed-header] > tbody > tr');
+                    var clonedTrElem;
+                    var firstTrIdx = 0;
+                    for (; firstTrIdx < clonedTrElems.length; firstTrIdx++) { // Find the first tbody row that has the same number of columns as the header (no colspan'd cells)
+                        if (clonedTrElems[firstTrIdx].childElementCount === clonedTheadRow.childElementCount) {
+                            clonedTrElem = clonedTrElems[firstTrIdx];
+                            break;
+                        }
+                    }
+                    angular.forEach(clonedTheadRow.querySelectorAll('tr:first-child > th'), function (clonedThElem, i) {
+                        var clonedTdElems = clonedTrElem ? clonedTrElem.querySelector('th:nth-child(' + (i + 1) + '):not([colspan]), td:nth-child(' + (i + 1) + '):not([colspan])') : null;
                         var columnWidth = clonedTdElems ? clonedTdElems.offsetWidth : clonedThElem.offsetWidth;
-                        var tdElems = elem.querySelector('table[fixed-header] > tbody > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tbody > tr:first-child > td:nth-child(' + (i + 1) + ')');
+                        var tdElems = elem.querySelector('table[fixed-header] > tbody > tr:nth-child(' + (firstTrIdx + 1) + ') > th:nth-child(' + (i + 1) + '), table[fixed-header] > tbody > tr:nth-child(' + (firstTrIdx + 1) + ') > td:nth-child(' + (i + 1) + ')');
                         var thElems = elem.querySelector('table[fixed-header] > thead > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > thead > tr:first-child > td:nth-child(' + (i + 1) + ')');
                         var tfElems = elem.querySelector('table[fixed-header] > tfoot > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tfoot > tr:first-child > td:nth-child(' + (i + 1) + ')');
                         if (tdElems)  {

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -8,9 +8,9 @@
         .module('anguFixedHeaderTable', [])
         .directive('fixedHeader', fixedHeader);
 
-    fixedHeader.$inject = ['$timeout'];
+    fixedHeader.$inject = ['$timeout', '$window'];
 
-    function fixedHeader($timeout) {
+    function fixedHeader($timeout, $window) {
         return {
             restrict: 'A',
             link: link
@@ -25,57 +25,95 @@
                     transformTable();
                 }
             });
-
+            
             function tableDataLoaded() {
                 // first cell in the tbody exists when data is loaded but doesn't have a width
                 // until after the table is transformed
-                var firstCell = elem.querySelector('tbody tr:first-child td:first-child');
+                var firstCell = elem.querySelector('table[fixed-header] > tbody > tr:first-child > td:first-child');
                 return firstCell && !firstCell.style.width;
+            }
+            
+            // make sure to accommodate the scroll bar width if the tbody changes from/to not overflowing
+            $scope.$watch(numRows, function (newVal, oldVal) {
+                if (newVal !== oldVal) {
+                    transformTable();
+                } 
+            });
+
+            function numRows() {
+                return elem.querySelectorAll('table[fixed-header] > tbody > tr').length;
             }
 
             function transformTable() {
-                // reset display styles so column widths are correct when measured below
-                angular.element(elem.querySelectorAll('thead, tbody, tfoot')).css('display', '');
-
                 // wrap in $timeout to give table a chance to finish rendering
                 $timeout(function () {
+                    // Instead of doing any calculations on elem, we will do them on a clone.
+                    // This way we won't change the display of the table itself, preventing FOUC when transforming.
+                    var clone = elem.cloneNode(true);
+                    var wrapper = document.createElement('div');
+                    wrapper.style.height = '0px';
+                    wrapper.style.overflow = 'hidden';
+                    wrapper.style.visibility = 'invisible';
+                    wrapper.appendChild(clone);
+                    angular.element(clone.querySelectorAll('thead, tbody, tfoot')).css('display', '');
+                    $elem.parent()[0].appendChild(wrapper);
                     // set widths of columns
-                    angular.forEach(elem.querySelectorAll('tr:first-child th'), function (thElem, i) {
-
-                        var tdElems = elem.querySelector('tbody tr:first-child td:nth-child(' + (i + 1) + ')');
-                        var tfElems = elem.querySelector('tfoot tr:first-child td:nth-child(' + (i + 1) + ')');
-
-                        var columnWidth = tdElems ? tdElems.offsetWidth : thElem.offsetWidth;
-                        if (tdElems) {
+                    angular.forEach(clone.querySelectorAll('table[fixed-header] > thead > tr:first-child > th'), function (clonedThElem, i) {
+                        var clonedTdElems = clone.querySelector('table[fixed-header] > tbody > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tbody > tr:first-child > td:nth-child(' + (i + 1) + ')');
+                        var columnWidth = clonedTdElems ? clonedTdElems.offsetWidth : clonedThElem.offsetWidth;
+                        var tdElems = elem.querySelector('table[fixed-header] > tbody > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tbody > tr:first-child > td:nth-child(' + (i + 1) + ')');
+                        var thElems = elem.querySelector('table[fixed-header] > thead > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > thead > tr:first-child > td:nth-child(' + (i + 1) + ')');
+                        var tfElems = elem.querySelector('table[fixed-header] > tfoot > tr:first-child > th:nth-child(' + (i + 1) + '), table[fixed-header] > tfoot > tr:first-child > td:nth-child(' + (i + 1) + ')');
+                        if (tdElems)  {
                             tdElems.style.width = columnWidth + 'px';
                         }
-                        if (thElem) {
-                            thElem.style.width = columnWidth + 'px';
+                        if (thElems) {
+                            thElems.style.width = columnWidth + 'px';
                         }
-                        if (tfElems) {
+                        if (tfElems)  {
                             tfElems.style.width = columnWidth + 'px';
                         }
                     });
+                    
+                    //Done with the math. We can get rid of the clone.
+                    angular.element(wrapper).remove();
 
                     // set css styles on thead and tbody
-                    angular.element(elem.querySelectorAll('thead, tfoot')).css('display', 'block');
-
-                    angular.element(elem.querySelectorAll('tbody')).css({
+                    angular.element(elem.querySelectorAll('table[fixed-header] > thead, table[fixed-header] > tfoot')).css('display', 'block');
+                    angular.element(elem.querySelector('table[fixed-header] > tbody')).css({
                         'display': 'block',
                         'height': $attrs.tableHeight || 'inherit',
+                        'max-height': $attrs.maxTableHeight || 'inherit',
                         'overflow': 'auto'
                     });
 
+                    // Fix tr inheritance of tbody height in IE9.
+                    // This whole directive doesn't actually work in IE9 but this fix
+                    // makes the table look ok when it degrades to a normal table
+                    angular.element(elem.querySelectorAll('table[fixed-header] > tbody > tr')).css('height', 'auto');
+
                     // reduce width of last column by width of scrollbar
-                    var tbody = elem.querySelector('tbody');
+                    var tbody = elem.querySelector('table[fixed-header] > tbody');
                     var scrollBarWidth = tbody.offsetWidth - tbody.clientWidth;
+                    
                     if (scrollBarWidth > 0) {
-                        // for some reason trimming the width by 2px lines everything up better
-                        scrollBarWidth -= 2;
-                        var lastColumn = elem.querySelector('tbody tr:first-child td:last-child');
+                        // for some reason trimming the width by 4px lines everything up better
+                        scrollBarWidth -= 4;
+                        var lastColumn = elem.querySelector('table[fixed-header] > tbody > tr:first-child > td:last-child');
                         lastColumn.style.width = (lastColumn.offsetWidth - scrollBarWidth) + 'px';
                     }
                 });
+            }
+
+            angular.element($window).bind('resize', resizeThrottler);
+            var resizeTimeout;
+            function resizeThrottler() {
+                if (!resizeTimeout) {
+                    resizeTimeout = $timeout(function() {
+                        resizeTimeout = null;
+                        transformTable();
+                    }, 100);
+                }
             }
         }
     }

--- a/angu-fixed-header-table.js
+++ b/angu-fixed-header-table.js
@@ -72,8 +72,7 @@
                                 cells[k].style.width = cloneRows[j].children[k].offsetWidth + 'px';
                             }
                         }
-                    };
-
+                    }
                     
                     //Done with the math. We can get rid of the clone.
                     angular.element(wrapper).remove();

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -47,6 +47,10 @@
                 <th>Header 2</th>
                 <th>Header 3</th>
                 <th>Header 4</th>
+                <th>Header 5</th>
+            </tr>
+            <tr>
+                <th colspan="5">Another Header 1 - 4</th>
             </tr>
         </thead>
         <tbody ng-init="items = [1,2,3,4]">
@@ -55,14 +59,18 @@
                 <td>Row {{item}} Col 2</td>
                 <td>Row {{item}} Col 3</td>
                 <td>Row {{item}} Col 4</td>
+                <td>Row {{item}} Col 5</td>
+            </tr>
+            <tr>
+                <td colspan="2">Extra Row Col 1 - 2</td>
+                <td colspan="3">Extra Row Col 3 - 5</td>
             </tr>
         </tbody>
         <tfoot>
             <tr>
-                <td>Footer 1</td>
-                <td>Footer 2</td>
+                <td colspan="2">Footer 1 - 2</td>
                 <td>Footer 3</td>
-                <td>Footer 4</td>
+                <td colspan="2">Footer 4 - 5</td>
             </tr>
         </tfoot>
     </table>

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -6,14 +6,14 @@
     <title>AngularJS Fixed Header Scrollable Table</title>
     <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" />
     <style>
-        .table {
+        .table-400 {
             height: 400px;
         }
     </style>
 </head>
 
 <body>
-    <table class="table table-bordered" fixed-header>
+    <table class="table table-400 table-bordered" fixed-header>
         <thead>
             <tr>
                 <th>Header 1</th>
@@ -39,6 +39,37 @@
             </tr>
         </tfoot>
     </table>
+
+    <table class="table table-bordered" fixed-header max-table-height="210px">
+        <thead>
+            <tr>
+                <th>Header 1</th>
+                <th>Header 2</th>
+                <th>Header 3</th>
+                <th>Header 4</th>
+            </tr>
+        </thead>
+        <tbody ng-init="items = [1,2,3,4]">
+            <tr ng-repeat="item in items">
+                <td>Row {{item}} Col 1</td>
+                <td>Row {{item}} Col 2</td>
+                <td>Row {{item}} Col 3</td>
+                <td>Row {{item}} Col 4</td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr>
+                <td>Footer 1</td>
+                <td>Footer 2</td>
+                <td>Footer 3</td>
+                <td>Footer 4</td>
+            </tr>
+        </tfoot>
+    </table>
+    <p>
+        <button type="button" class="btn btn-primary btn-sm" ng-click="items.push(items.length + 1)">Add an item</button>
+        <button type="button" class="btn btn-primary btn-sm" ng-click="items.pop()">Delete an item</button>
+    </p>
 
     <script src="https://code.angularjs.org/1.2.16/angular.js"></script>
     <script src="../angu-fixed-header-table.js"></script>


### PR DESCRIPTION
Includes some fixes brought in from @Dorian-Fusco's PR, but without dramatic changes to look/functionality of original directive.

From @Dorian-Fusco PR #13 :
- Less promiscuous selectors.
- Perform calculations on hidden clone rather than original element to prevent FOUCs.

Other fixes/improvements:
- Perform `transformTable` when the number of rows of the `tbody` change to
  accommodate scrollbar disappearing/reappearing with live data. Updated demo with example.
- Perform `transformTable` on throttled window resize so that the table columns aren't stuck at a maximum of their originally calculated size.
- Increased `scrollBarWidth` trim to -4px. Testing the demo in several
  browsers/platforms seemed to indicate this was better than -2px.
- Fix for IE9 `tr` height inheritance so that even though the directive fails it at least falls back to a normal looking table.
