### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ angu-fixed-header-table
 
 An AngularJS fixed header scrollable table directive
 
-###Demo
+### Demo
 
 To see a demo and further details go to http://pointblankdevelopment.com.au/blog/angularjs-fixed-header-scrollable-table-directive
 
-###Installation
+### Installation
 
 Install using bower: `bower install angu-fixed-header-table`
 
@@ -19,7 +19,7 @@ Add the 'anguFixedHeaderTable' directive as a dependency of your AngularJS appli
 angular.module('myApp', ['anguFixedHeaderTable']);
 ```
 
-###Usage
+### Usage
 
 Simply add the *fixed-header* attribute to any tables you'd like to have a fixed header:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
